### PR TITLE
PS-595 helm release synchronize job

### DIFF
--- a/charts/phrasea/Chart.yaml
+++ b/charts/phrasea/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.13.0-alpha11
+version: 2.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/phrasea/values.yaml
+++ b/charts/phrasea/values.yaml
@@ -419,8 +419,6 @@ mailer:
   replyTo:
   replyToDisplayName:
   envelopeFrom:
-  dsn: 
-
 
 postgresql:
   enabled: true


### PR DESCRIPTION
PS-595 This PR synchronizes the Helm release by cleaning up unused mailer settings and promoting the chart from alpha to a stable version.

Remove placeholder dsn entry under mailer in values.yaml
Bump version in Chart.yaml from 2.13.0-alpha11 to 2.13.0