### PR TITLE
Align migration job resources with worker limits/requests

### DIFF
--- a/charts/phrasea/Chart.yaml
+++ b/charts/phrasea/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.23.0-beta1
+version: 2.23.0-beta2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 4.0.0
+appVersion: 4.1.0
 
 dependencies:
   - name: elasticsearch

--- a/charts/phrasea/templates/configurator/migrate-job.yaml
+++ b/charts/phrasea/templates/configurator/migrate-job.yaml
@@ -18,6 +18,15 @@ spec:
       {{- end }}
       containers:
       - {{- include "configurator.containerSpecs" $ | nindent 8 }}
+        {{- if eq "true" (include "ps.resourceQuota" (dict "local" $.Values.configurator.resourceQuota "global" $.Values.resourceQuota)) }}
+        resources:
+          requests:
+            memory: {{ $.Values.configurator.resources.requests.memory | default "256Mi" }}
+            cpu: {{ $.Values.configurator.resources.requests.cpu | default "50m" }}
+          limits:
+            memory: {{ $.Values.configurator.resources.limits.memory | default "2048Mi" }}
+            cpu: {{ $.Values.configurator.resources.limits.cpu | default "2000m" }}
+        {{- end }}
         args: ["bin/migrate.sh"]
       restartPolicy: Never
   backoffLimit: 3

--- a/charts/phrasea/templates/migrate-job.yaml
+++ b/charts/phrasea/templates/migrate-job.yaml
@@ -21,6 +21,15 @@ spec:
       - name: {{ $appName }}-php-job
         image: {{ $.Values.repository.baseUrl }}/ps-{{ $appName }}-api-php:{{ $.Values.repository.tag }}
         imagePullPolicy: {{ $.Values.repository.imagePullPolicy }}
+        {{- if eq "true" (include "ps.resourceQuota" (dict "local" (index $.Values $appName).worker.resourceQuota "global" $.Values.resourceQuota)) }}
+        resources:
+          requests:
+            memory: {{ (index $.Values $appName).worker.resources.requests.memory | default "256Mi" }}
+            cpu: {{ (index $.Values $appName).worker.resources.requests.cpu | default "50m" }}
+          limits:
+            memory: {{ (index $.Values $appName).worker.resources.limits.memory | default "2048Mi" }}
+            cpu: {{ (index $.Values $appName).worker.resources.limits.cpu | default "2000m" }}
+        {{- end }}
         args: ["bin/migrate.sh"]
         terminationMessagePolicy: FallbackToLogsOnError
         env:

--- a/charts/phrasea/values.yaml
+++ b/charts/phrasea/values.yaml
@@ -124,6 +124,16 @@ configurator:
     externalSecretMapping:
       accessKey: CONFIGURATOR_S3_ACCESS_KEY
       secretKey: CONFIGURATOR_S3_SECRET_KEY
+  # Used by configurator migration/setup/synchronize jobs.
+  # Override global resourceQuota for this service (true/false), defaults to global value
+  # resourceQuota:
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "256Mi"
+    limits:
+      cpu: "2000m"
+      memory: "2048Mi"
 
 interactivePod:
   # Set to true to launch an interactive pod for debugging


### PR DESCRIPTION
applies the same resource requests/limits as workers to migration jobs for databox, expose, and uploader.
It also updates configurator migration to use configurator.resources